### PR TITLE
fix: convert relative links to absolute GitHub URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ Each item needs an id, status (draft/pending/approve/reject), and tags.
 | `edit`            | Browser-based data editor                                 |
 | `workflow-status` | Track pipeline progress                                   |
 
-See the [CLI Reference](docs/manual/en/cli-reference.md) for full details.
+See the [CLI Reference](https://github.com/gospelo-dev/kata/blob/main/docs/manual/en/cli-reference.md) for full details.
 
 ## AI Integration
 
@@ -231,17 +231,17 @@ The `kata-lint` extension provides:
 - Hover information for `data-kata` attributes
 - Preview CSS for kata-specific styles
 
-See the [VSCode Integration Guide](docs/manual/en/vscode-integration.md).
+See the [VSCode Integration Guide](https://github.com/gospelo-dev/kata/blob/main/docs/manual/en/vscode-integration.md).
 
 ## Documentation
 
-- [Quick Start](docs/manual/en/quick-start.md)
-- [CLI Reference](docs/manual/en/cli-reference.md)
-- [KATA Markdown Format](docs/manual/en/kata-markdown-format.md)
-- [Lint Rules](docs/manual/en/lint-rules.md)
-- [Workflow Guide](docs/manual/en/workflow-guide.md)
-- [VSCode Integration](docs/manual/en/vscode-integration.md)
-- [Copilot Setup](docs/manual/en/copilot-setup.md)
+- [Quick Start](https://github.com/gospelo-dev/kata/blob/main/docs/manual/en/quick-start.md)
+- [CLI Reference](https://github.com/gospelo-dev/kata/blob/main/docs/manual/en/cli-reference.md)
+- [KATA Markdown Format](https://github.com/gospelo-dev/kata/blob/main/docs/manual/en/kata-markdown-format.md)
+- [Lint Rules](https://github.com/gospelo-dev/kata/blob/main/docs/manual/en/lint-rules.md)
+- [Workflow Guide](https://github.com/gospelo-dev/kata/blob/main/docs/manual/en/workflow-guide.md)
+- [VSCode Integration](https://github.com/gospelo-dev/kata/blob/main/docs/manual/en/vscode-integration.md)
+- [Copilot Setup](https://github.com/gospelo-dev/kata/blob/main/docs/manual/en/copilot-setup.md)
 
 ## License
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -210,7 +210,7 @@ categories:
 | `edit`            | ブラウザベースのデータエディター                              |
 | `workflow-status` | パイプラインの進捗管理                                        |
 
-詳細は [CLI リファレンス](docs/manual/ja/cli-reference.md) を参照。
+詳細は [CLI リファレンス](https://github.com/gospelo-dev/kata/blob/main/docs/manual/ja/cli-reference.md) を参照。
 
 ## AI 連携
 
@@ -231,17 +231,17 @@ gospelo-kata は AI アシスタントとの連携を前提に設計されてい
 - `data-kata` 属性のホバー情報
 - kata 専用スタイルのプレビュー CSS
 
-詳細は [VSCode 連携ガイド](docs/manual/ja/vscode-integration.md) を参照。
+詳細は [VSCode 連携ガイド](https://github.com/gospelo-dev/kata/blob/main/docs/manual/ja/vscode-integration.md) を参照。
 
 ## ドキュメント
 
-- [クイックスタート](docs/manual/ja/quick-start.md)
-- [CLI リファレンス](docs/manual/ja/cli-reference.md)
-- [KATA Markdown フォーマット](docs/manual/ja/kata-markdown-format.md)
-- [Lint ルール一覧](docs/manual/ja/lint-rules.md)
-- [ワークフローガイド](docs/manual/ja/workflow-guide.md)
-- [VSCode 連携](docs/manual/ja/vscode-integration.md)
-- [Copilot セットアップ](docs/manual/ja/copilot-setup.md)
+- [クイックスタート](https://github.com/gospelo-dev/kata/blob/main/docs/manual/ja/quick-start.md)
+- [CLI リファレンス](https://github.com/gospelo-dev/kata/blob/main/docs/manual/ja/cli-reference.md)
+- [KATA Markdown フォーマット](https://github.com/gospelo-dev/kata/blob/main/docs/manual/ja/kata-markdown-format.md)
+- [Lint ルール一覧](https://github.com/gospelo-dev/kata/blob/main/docs/manual/ja/lint-rules.md)
+- [ワークフローガイド](https://github.com/gospelo-dev/kata/blob/main/docs/manual/ja/workflow-guide.md)
+- [VSCode 連携](https://github.com/gospelo-dev/kata/blob/main/docs/manual/ja/vscode-integration.md)
+- [Copilot セットアップ](https://github.com/gospelo-dev/kata/blob/main/docs/manual/ja/copilot-setup.md)
 
 ## ライセンス
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "gospelo-kata"
 version = "0.1.0"
-description = "JSON-driven document generation toolkit: validate, generate, and edit structured documents"
+description = "KATA Markdown toolkit for human-AI collaboration: schema, validation, and template in a single file"
 readme = "README.md"
 license = "MIT"
 requires-python = ">=3.11"
@@ -39,7 +39,7 @@ classifiers = [
 gospelo-kata = "gospelo_kata.cli:main"
 
 [project.urls]
-Repository = "https://github.com/gospelo/kata"
+Repository = "https://github.com/gospelo-dev/kata"
 
 [tool.hatch.build.targets.sdist]
 include = [


### PR DESCRIPTION
## Summary

- Convert relative doc links in README.md and README_ja.md to absolute GitHub URLs for PyPI compatibility
- Update pyproject.toml description and repository URL

## Test plan

- [ ] Verify links render correctly on PyPI project page

🤖 Generated with [Claude Code](https://claude.com/claude-code)