### PR TITLE
hotfix: fix D003 false positive (v0.4.1)

### DIFF
--- a/gospelo_kata/__init__.py
+++ b/gospelo_kata/__init__.py
@@ -4,4 +4,4 @@
 
 """gospelo-kata: JSON-driven document generation toolkit."""
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"

--- a/gospelo_kata/linter.py
+++ b/gospelo_kata/linter.py
@@ -744,6 +744,16 @@ def lint_document(
     return result
 
 
+def _mask_pipes_in_spans(line: str) -> str:
+    """Replace pipe characters inside backticks and Jinja2 tags with a placeholder."""
+    # Mask pipes inside backtick spans
+    result = re.sub(r"`[^`]*`", lambda m: m.group().replace("|", "\x00"), line)
+    # Mask pipes inside Jinja2 expression/statement tags
+    result = re.sub(r"\{\{.*?\}\}", lambda m: m.group().replace("|", "\x00"), result)
+    result = re.sub(r"\{%.*?%\}", lambda m: m.group().replace("|", "\x00"), result)
+    return result
+
+
 def _check_table_columns(text: str, messages: list[LintMessage]) -> None:
     """Check that tables have consistent column counts."""
     lines = text.split("\n")
@@ -753,7 +763,8 @@ def _check_table_columns(text: str, messages: list[LintMessage]) -> None:
     for i, line in enumerate(lines, 1):
         stripped = line.strip()
         if stripped.startswith("|") and stripped.endswith("|"):
-            cells = [c.strip() for c in stripped.split("|")[1:-1]]
+            masked = _mask_pipes_in_spans(stripped)
+            cells = [c.strip() for c in masked.split("|")[1:-1]]
             # Skip separator rows
             if all(c.replace("-", "").replace(":", "") == "" for c in cells):
                 continue

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "gospelo-kata"
-version = "0.4.0"
+version = "0.4.1"
 description = "KATA Markdown™ toolkit for human-AI collaboration: schema, validation, and template in a single file"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_linter.py
+++ b/tests/test_linter.py
@@ -345,6 +345,21 @@ class TestDocumentModeLint:
         codes = [m.code for m in result.messages]
         assert "D003" in codes
 
+    def test_lint_document_table_pipe_in_backtick_no_d003(self):
+        """Pipes inside backticks or Jinja2 tags should not cause D003."""
+        from gospelo_kata.linter import lint_document
+        text = (
+            "# Test\n\n"
+            "## Cases\n\n"
+            "| Field | Value |\n"
+            "|-------|-------|\n"
+            '| Priority | {{ case.priority | default("medium") }} |\n'
+            '| Body | `{"key": "a|b"}` |\n\n'
+        )
+        result = lint_document(text, "agenda")
+        codes = [m.code for m in result.messages]
+        assert "D003" not in codes
+
     def test_lint_document_empty_section(self):
         from gospelo_kata.linter import lint_document
         text = (


### PR DESCRIPTION
## Summary
- D003 (Table column count mismatch) was falsely triggered by pipe characters inside backtick spans and Jinja2 template tags (`{{ x | filter }}`)
- Added `_mask_pipes_in_spans()` to neutralize pipes inside backticks/Jinja2 tags before column counting
- Version bumped to 0.4.1 for pip hotfix release

## Test plan
- [x] Existing 65 linter tests pass
- [x] New test: pipes in backticks/Jinja2 do not trigger D003
- [x] `gospelo-kata lint api_test_data.kata.md` returns OK (was WARNING before)
- [x] All 320 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)